### PR TITLE
Upgrade and add multiple active purges

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
-gem "dotenv"
-gem "matrix_sdk", "~> 0.0.3"
-gem "pg"
+gem 'dotenv'
+gem 'matrix_sdk', '~> 1'
+gem 'pg'
+gem 'ruby-progressbar'
 
 group :development do
-  gem "pry"
+  gem 'pry'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GEM
     logging (2.2.2)
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
-    matrix_sdk (0.0.3)
+    matrix_sdk (1.2.0)
       logging (~> 2)
     method_source (0.9.0)
     multi_json (1.13.1)
@@ -15,15 +15,17 @@ GEM
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    ruby-progressbar (1.10.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   dotenv
-  matrix_sdk (~> 0.0.3)
+  matrix_sdk (~> 1)
   pg
   pry
+  ruby-progressbar
 
 BUNDLED WITH
-   1.16.4
+   1.17.2

--- a/purge_worker.rb
+++ b/purge_worker.rb
@@ -74,7 +74,7 @@ class PurgeWorker
         end
 
         active[room] = purge_id
-      else
+      else # if active.count >= max_active
         # Update the purge status on all active purges
         active.each do |room, purge_id|
           begin
@@ -85,9 +85,9 @@ class PurgeWorker
             visualizer.room_end
             active.delete room
           rescue StandardError => e
-            # Makes output a bit too spammy during connection failures or
-            # Synapse overloads
-            #  visualizer.room_fail room, e.to_s
+            ## Makes output a bit too spammy during connection failures or
+            ## Synapse overloads
+            # visualizer.room_fail room, e.to_s
             true
           end
         end

--- a/purge_worker.rb
+++ b/purge_worker.rb
@@ -61,9 +61,11 @@ class PurgeWorker
         rescue MatrixSdk::MatrixConnectionError => e
           visualizer.room_fail(room, e.message)
           to_purge.push(room)
+          next
         rescue EOFError => e
           visualizer.room_fail(room, e.to_s)
           to_purge.push(room)
+          next
         end
 
         # If only allowing one purge at the same time, skip the multi-purge code

--- a/purge_worker.rb
+++ b/purge_worker.rb
@@ -2,7 +2,8 @@
 
 class PurgeWorker
   attr_reader :client, :rooms, :max_active
-  attr_accessor :since, :visualizer
+  attr_writer :visualizer
+  attr_accessor :since
 
   def initialize(client, rooms,
                  ignore_local: true,
@@ -18,9 +19,12 @@ class PurgeWorker
 
     @client = client
     @rooms = rooms
-    @visualizer = Visualizers::Plain.new(self)
     self.max_active = max_active
     @since = since
+  end
+
+  def visualizer
+    @visualizer ||= Visualizers::Plain.new(self)
   end
 
   def max_active=(max_active)

--- a/purge_worker.rb
+++ b/purge_worker.rb
@@ -68,7 +68,7 @@ class PurgeWorker
 
         # If only allowing one purge at the same time, skip the multi-purge code
         if max_active == 1
-          client.wait_for_purge_completion(purge_id)
+          client.wait_for_purge_completion(purge_id) { visualizer.update }
           visualizer.room_end(room)
           next
         end

--- a/purge_worker.rb
+++ b/purge_worker.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+class PurgeWorker
+  attr_reader :client, :rooms, :max_active
+  attr_accessor :since, :visualizer
+
+  def initialize(client, rooms,
+                 ignore_local: true,
+                 max_active: 5,
+                 since: 24 * 60 * 60)
+    if ignore_local
+      local_domain = MatrixSdk::MXID.new(client.client.mxid).domain
+      rooms = rooms.reject do |r|
+        r = MatrixSdk::MXID.new r.to_s
+        r.domain == local_domain
+      end
+    end
+
+    @client = client
+    @rooms = rooms
+    @visualizer = Visualizers::Plain.new(self)
+    self.max_active = max_active
+    @since = since
+  end
+
+  def max_active=(max_active)
+    max_active = rooms.count if max_active <= 0
+
+    @max_active = max_active
+  end
+
+  def run
+    to_purge = rooms.dup
+    active = {}
+
+    visualizer.begin
+
+    loop do
+      break if active.empty? && to_purge.empty?
+
+      if active.count < max_active
+        room = to_purge.shift
+
+        purge_id = nil
+        begin
+          purge_id = client.enqueue_room_purge(room, since)
+          visualizer.room_begin(room)
+
+        # HTTP 4xx means a purge is either running or not able to run,
+        # so skip the current room
+        rescue MatrixSdk::MatrixRequestError => e
+          visualizer.room_fail(room, e.message)
+          visualizer.room_end(room)
+          next
+
+        # Don't skip the purge on HTTP 5XX or connection errors
+        rescue MatrixSdk::MatrixConnectionError => e
+          visualizer.room_fail(room, e.message)
+          to_purge.push(room)
+        rescue EOFError => e
+          visualizer.room_fail(room, e.to_s)
+          to_purge.push(room)
+        end
+
+        # If only allowing one purge at the same time, skip the multi-purge code
+        if max_active == 1
+          client.wait_for_purge_completion(purge_id)
+          visualizer.room_end(room)
+          next
+        end
+
+        active[room] = purge_id
+      else
+        # Update the purge status on all active purges
+        active.each do |room, purge_id|
+          begin
+            status = client.get_purge_status(purge_id)
+
+            next unless status == :active
+
+            visualizer.room_end
+            active.delete room
+          rescue StandardError => e
+            # Makes output a bit too spammy during connection failures or
+            # Synapse overloads
+            #  visualizer.room_fail room, e.to_s
+            true
+          end
+        end
+
+        visualizer.update
+        sleep 1
+      end
+    end
+
+    visualizer.end
+  end
+end

--- a/purge_worker.rb
+++ b/purge_worker.rb
@@ -80,9 +80,7 @@ class PurgeWorker
         # Update the purge status on all active purges
         active.each do |room, purge_id|
           begin
-            status = client.get_purge_status(purge_id)
-
-            next unless status == :active
+            next unless client.purge_finished?(purge_id)
 
             visualizer.room_end
             active.delete room

--- a/synapse-purge.rb
+++ b/synapse-purge.rb
@@ -1,15 +1,18 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'bundler/setup'
 require 'dotenv/load'
 require 'matrix_sdk'
-require 'ruby-progressbar'
 
+require './purge_worker'
+require './visualizer'
 require './synapse_client'
 require './synapse_db'
 
 puts 'Setting up DB link...'
 db = SynapseDb.new ENV.fetch('DATABASE_URL')
+
 puts 'Setting up Synapse link...'
 client = SynapseClient.new(
   url: ENV.fetch('HOMESERVER_URL'),
@@ -17,90 +20,25 @@ client = SynapseClient.new(
   username: ENV.fetch('ADMIN_USERNAME', nil),
   password: ENV.fetch('ADMIN_PASSWORD', nil)
 )
+
+# Read environment variables
 days = ENV.fetch('DAYS_TO_KEEP', 120).to_i
 since = Time.now - (24 * 60 * 60 * days)
 max_active = ENV.fetch('MAX_ACTIVE_PURGES', 5).to_i
+verbose = ENV.fetch('VERBOSE', 0).to_i == 1
+ignore_local = ENV.fetch('IGNORE_LOCAL', 1).to_i == 1
 
 puts 'Fetching rooms from DB...'
 rooms = db.rooms
-max_active = rooms.count if max_active <= 0
 
-progressbar = ProgressBar.create \
-  format: '%c/%C %t (%p%%) |%B| %a',
-  title: 'Purged'
-progressbar.total = rooms.count
+purge_client = PurgeWorker.new client, rooms,
+                               ignore_local: ignore_local,
+                               max_active: max_active,
+                               since: since
 
-header = "Purging events since #{since} (#{since.to_i * 1000}) in #{rooms.count} rooms...\n"
-total = header
+purge_client.visualizer = Visualizers::Verbose.new(purge_client) if verbose
 
-# STDOUT.sync = true
-
-max_width = 0
-purges = rooms.map do |r|
-  w = r.to_s.size
-  max_width = w if w > max_width
-  { room: r, id: nil, status: :not_started }
-end
-
-iter = 0
-loop do
-  iter += 1
-  unstarted = purges.select { |p| p[:status] == :not_started }.count
-  active = purges.select { |p| p[:status] == :active }.count
-
-  total = header + "\n" \
-    + purges.map do |p|
-      "%<room>#{max_width}s => %<status>s %<message>s" % {
-        room: p[:room].to_s,
-        status: p[:status],
-        message: p[:message]
-      }
-    end.join("\n") + "\n\n"
-
-  Gem.win_platform? ? (system 'cls') : (system 'clear')
-  progressbar.log total
-
-  break if active.zero? && unstarted.zero?
-
-  if active < max_active && unstarted > 0
-    entry = purges.select { |p| p[:status] == :not_started }.first
-    room = entry[:room]
-
-    begin
-      purge_id = client.enqueue_room_purge(room.id, since)
-      entry[:id] = purge_id
-      entry[:status] = :active
-    rescue MatrixSdk::MatrixRequestError => e
-      # warn "error purging #{room}: #{e.message}"
-      entry[:status] = :skipped
-      entry[:message] = e.message
-
-      progressbar.increment
-    rescue MatrixSdk::MatrixConnectionError => e
-      # Connection error, shift to end
-      entry[:message] = e.to_s
-      # else
-      # client.wait_for_purge_completion(purge_id)
-    end
-
-    purges.delete entry
-    purges << entry
-  end
-
-  if (iter % 5).zero?
-    purges.each do |p|
-      next unless p[:status] == :active
-
-      begin
-        p[:status] = client.get_purge_status(p[:id])
-
-        progressbar.increment if p[:status] != :active
-      rescue StandardError
-      end
-    end
-  end
-
-  sleep 1
-end
+puts 'Starting purge...'
+purge_client.run
 
 client.logout

--- a/synapse-purge.rb
+++ b/synapse-purge.rb
@@ -3,33 +3,104 @@
 require 'bundler/setup'
 require 'dotenv/load'
 require 'matrix_sdk'
+require 'ruby-progressbar'
 
 require './synapse_client'
 require './synapse_db'
 
+puts 'Setting up DB link...'
 db = SynapseDb.new ENV.fetch('DATABASE_URL')
+puts 'Setting up Synapse link...'
 client = SynapseClient.new(
   url: ENV.fetch('HOMESERVER_URL'),
-  username: ENV.fetch('ADMIN_USERNAME'),
-  password: ENV.fetch('ADMIN_PASSWORD')
+  token: ENV.fetch('ADMIN_TOKEN', nil),
+  username: ENV.fetch('ADMIN_USERNAME', nil),
+  password: ENV.fetch('ADMIN_PASSWORD', nil)
 )
 days = ENV.fetch('DAYS_TO_KEEP', 120).to_i
-since = Time.now - (24*60*60*days)
+since = Time.now - (24 * 60 * 60 * days)
+max_active = ENV.fetch('MAX_ACTIVE_PURGES', 5).to_i
+
+puts 'Fetching rooms from DB...'
 rooms = db.rooms
+max_active = rooms.count if max_active <= 0
 
-STDOUT.sync = true
-puts "Purging events since #{since.to_s} (#{since.to_i * 1000}) in #{rooms.count} rooms"
+progressbar = ProgressBar.create \
+  format: '%c/%C %t (%p%%) |%B| %a',
+  title: 'Purged'
+progressbar.total = rooms.count
 
-rooms.each do |room|
-  puts(room)
+header = "Purging events since #{since} (#{since.to_i * 1000}) in #{rooms.count} rooms...\n"
+total = header
 
-  begin
-    purge_id = client.enqueue_room_purge(room.id, since)
-  rescue MatrixSdk::MatrixRequestError => e
-    STDERR.puts "error purging #{room}: #{e.message}"
-  else
-    client.wait_for_purge_completion(purge_id)
-  end
+# STDOUT.sync = true
+
+max_width = 0
+purges = rooms.map do |r|
+  w = r.to_s.size
+  max_width = w if w > max_width
+  { room: r, id: nil, status: :not_started }
 end
 
-puts "Done."
+iter = 0
+loop do
+  iter += 1
+  unstarted = purges.select { |p| p[:status] == :not_started }.count
+  active = purges.select { |p| p[:status] == :active }.count
+
+  total = header + "\n" \
+    + purges.map do |p|
+      "%<room>#{max_width}s => %<status>s %<message>s" % {
+        room: p[:room].to_s,
+        status: p[:status],
+        message: p[:message]
+      }
+    end.join("\n") + "\n\n"
+
+  Gem.win_platform? ? (system 'cls') : (system 'clear')
+  progressbar.log total
+
+  break if active.zero? && unstarted.zero?
+
+  if active < max_active && unstarted > 0
+    entry = purges.select { |p| p[:status] == :not_started }.first
+    room = entry[:room]
+
+    begin
+      purge_id = client.enqueue_room_purge(room.id, since)
+      entry[:id] = purge_id
+      entry[:status] = :active
+    rescue MatrixSdk::MatrixRequestError => e
+      # warn "error purging #{room}: #{e.message}"
+      entry[:status] = :skipped
+      entry[:message] = e.message
+
+      progressbar.increment
+    rescue MatrixSdk::MatrixConnectionError => e
+      # Connection error, shift to end
+      entry[:message] = e.to_s
+      # else
+      # client.wait_for_purge_completion(purge_id)
+    end
+
+    purges.delete entry
+    purges << entry
+  end
+
+  if (iter % 5).zero?
+    purges.each do |p|
+      next unless p[:status] == :active
+
+      begin
+        p[:status] = client.get_purge_status(p[:id])
+
+        progressbar.increment if p[:status] != :active
+      rescue StandardError
+      end
+    end
+  end
+
+  sleep 1
+end
+
+client.logout

--- a/synapse_client.rb
+++ b/synapse_client.rb
@@ -35,6 +35,8 @@ class SynapseClient
       break if purge_finished? purge_id
 
       sleep STATUS_CHECK_DELAY_IN_SECONDS
+
+      yield if block_given?
     end
   end
 

--- a/synapse_client.rb
+++ b/synapse_client.rb
@@ -5,6 +5,8 @@ require 'erb'
 class SynapseClient
   STATUS_CHECK_DELAY_IN_SECONDS = 0.5
 
+  attr_reader :client
+
   def initialize(url:, token: nil, username: nil, password: nil)
     @client = MatrixSdk::Client.new url
 

--- a/synapse_client.rb
+++ b/synapse_client.rb
@@ -1,26 +1,54 @@
+# frozen_string_literal: true
+
+require 'erb'
+
 class SynapseClient
   STATUS_CHECK_DELAY_IN_SECONDS = 0.5
 
-  def initialize(url:, username:, password:)
+  def initialize(url:, token: nil, username: nil, password: nil)
     @client = MatrixSdk::Client.new url
-    @client.login username, password, no_sync: true
+
+    if token
+      @client.access_token = token
+    else
+      @client.login username, password, no_sync: true
+    end
+  end
+
+  def logout
+    @client.logout
   end
 
   def enqueue_room_purge(room_id, since)
-    result = @client.api.request :post, :client_r0, "/admin/purge_history/#{URI.encode room_id}",
-      body: {purge_up_to_ts: since.to_i * 1000}
+    result = @client.api.request(
+      :post,
+      :client_r0, "/admin/purge_history/#{ERB::Util.url_encode room_id}",
+      body: { purge_up_to_ts: since.to_i * 1000 }
+    )
     result[:purge_id]
   end
 
   def wait_for_purge_completion(purge_id)
-    while true
-      break if get_purge_status(purge_id) != 'active'
+    loop do
+      break if purge_finished? purge_id
+
       sleep STATUS_CHECK_DELAY_IN_SECONDS
     end
   end
 
+  def purge_running?(purge_id)
+    get_purge_status(purge_id) == :active
+  end
+
+  def purge_finished?(purge_id)
+    get_purge_status(purge_id) != :active
+  end
+
   def get_purge_status(purge_id)
-    result = @client.api.request :get, :client_r0, "/admin/purge_history_status/#{purge_id}"
-    result[:status]
+    result = @client.api.request(
+      :get,
+      :client_r0, "/admin/purge_history_status/#{purge_id}"
+    )
+    result[:status].to_sym
   end
 end

--- a/synapse_db.rb
+++ b/synapse_db.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'uri'
 require 'pg'
 
@@ -11,24 +13,24 @@ class SynapseDb
     end
 
     def to_s
-      @id
+      @canonical_alias || @id
     end
   end
 
   def initialize(database_url)
     uri = URI.parse database_url
     @conn = PG.connect(
-                       host: uri.host,
-                       port: uri.port,
-                       user: uri.user,
-                       password: uri.password,
-                       dbname: uri.path[1..-1]
+      host: uri.host,
+      port: uri.port,
+      user: uri.user,
+      password: uri.password,
+      dbname: uri.path[1..-1]
     )
   end
 
   def rooms
     # TODO Get canonical_alias as well
-    @conn.exec("SELECT room_id FROM rooms") do |result|
+    @rooms ||= @conn.exec('SELECT room_id FROM rooms') do |result|
       result.map do |row|
         Room.new row
       end

--- a/visualizer.rb
+++ b/visualizer.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class Visualizer
+  attr_reader :worker
+
+  def initialize(worker)
+    @worker = worker
+  end
+
+  def begin; end
+
+  def update; end
+
+  def end; end
+
+  def room_begin(room); end
+
+  def room_fail(room, reason); end
+
+  def room_end(room); end
+
+  protected
+
+  def rooms
+    worker.rooms
+  end
+end
+
+module Visualizers
+  autoload :Plain, './visualizers/plain'
+  autoload :Verbose, './visualizers/verbose'
+end

--- a/visualizer.rb
+++ b/visualizer.rb
@@ -27,6 +27,7 @@ class Visualizer
 end
 
 module Visualizers
+  autoload :Dummy, './visualizers/dummy'
   autoload :Plain, './visualizers/plain'
   autoload :Verbose, './visualizers/verbose'
 end

--- a/visualizers/dummy.rb
+++ b/visualizers/dummy.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Visualizers
+  class Dummy < Visualizer
+  end
+end

--- a/visualizers/plain.rb
+++ b/visualizers/plain.rb
@@ -26,4 +26,3 @@ module Visualizers
     end
   end
 end
-

--- a/visualizers/plain.rb
+++ b/visualizers/plain.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Visualizers
+  class Plain < Visualizer
+    def begin
+      STDOUT.sync = true
+
+      puts
+      puts "Purging events since #{since} (#{since.to_i * 1000}) in #{rooms.count} rooms"
+      @start = Time.now
+    end
+
+    def end
+      @end = Time.now
+      duration = Time.at(@end - @start).utc.strftime('%H:%M:%S')
+
+      puts "Event purge finished in #{duration} seconds"
+    end
+
+    def room_begin(room)
+      puts room
+    end
+
+    def room_fail(room, reason)
+      warn "#{room}: #{reason}"
+    end
+  end
+end
+

--- a/visualizers/verbose.rb
+++ b/visualizers/verbose.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'ruby-progressbar'
+
+module Visualizers
+  class Verbose < Visualizer
+    attr_accessor :max_width
+
+    def begin
+      @max_width = 0
+      rooms.each do |r|
+        w = r.to_s.size
+        @max_width = w if w > @max_width
+      end
+
+      puts
+      progressbar.total = rooms.count
+    end
+
+    def update
+      progressbar.refresh
+    end
+
+    def end
+      progressbar.refresh
+    end
+
+    def room_begin(room)
+      progressbar.log format('%<room>s: begun',
+                             room: room.to_s.rjust(max_width))
+    end
+
+    def room_fail(room, reason)
+      progressbar.log format('%<room>s: errored, %<reason>s',
+                             room: room.to_s.rjust(max_width),
+                             reason: reason)
+    end
+
+    def room_end(room)
+      progressbar.log format('%<room>s: done',
+                             room: room.to_s.rjust(max_width))
+      progressbar.increment
+    end
+
+    def progressbar
+      @progressbar ||= ProgressBar.create \
+        format: '%c/%C %t (%p%%) |%B| %a',
+        title: 'Purged'
+    end
+  end
+end


### PR DESCRIPTION
This fixes a bunch of rubocop complaints and adds an env for choosing how many simultaneous active purges is to be used, defaulting to 5.  
The limit avoids overloading either Synapse or the backing Postgres server with actions.

The new output format is a bit more verbose, including a list of all rooms as well as their purge status, along with a progress bar and time elapsed at the bottom.

This is a rather major change, and the use of a progress bar is a bit opinionated, so I'm okay with moving the new output format to behind an environment flag if wanted.