### PR TITLE
Clean up the purge code slightly

### DIFF
--- a/compress_worker.rb
+++ b/compress_worker.rb
@@ -137,6 +137,11 @@ class CompressWorker
 
     begin
       db.conn.exec sql
+    rescue PG::UnableToSend
+      # Most likely lost connection to postgres, reconnect and try again
+      # TODO: Avoid breaking any running query?
+      db.conn.reset
+      db.conn.exec sql
     rescue PG::SyntaxError
       FileUtils.copy(temp.path, '/tmp/error.sql')
       puts 'Copied broken SQL to /tmp/error.sql'

--- a/compress_worker.rb
+++ b/compress_worker.rb
@@ -12,6 +12,7 @@ class CompressWorker
     @db = db
     @rooms = rooms
     @binary = binary
+    @dbmutex = Mutex.new
 
     self.max_active = max_active
     self.minimum_rows = minimum_rows
@@ -135,18 +136,20 @@ class CompressWorker
       result
     )
 
-    begin
-      db.conn.exec sql
-    rescue PG::UnableToSend
-      # Most likely lost connection to postgres, reconnect and try again
-      # TODO: Avoid breaking any running query?
-      db.conn.reset
-      db.conn.exec sql
-    rescue PG::SyntaxError
-      FileUtils.copy(temp.path, '/tmp/error.sql')
-      puts 'Copied broken SQL to /tmp/error.sql'
+    @dbmutex.synchronize do
+      begin
+        db.conn.exec sql
+      rescue PG::UnableToSend
+        # Most likely lost connection to postgres, reconnect and try again
+        # TODO: Avoid breaking any running query?
+        db.conn.reset
+        db.conn.exec sql
+      rescue PG::SyntaxError
+        FileUtils.copy(temp.path, '/tmp/error.sql')
+        puts 'Copied broken SQL to /tmp/error.sql'
 
-      raise
+        raise
+      end
     end
   ensure
     temp.unlink

--- a/purge_worker.rb
+++ b/purge_worker.rb
@@ -55,13 +55,13 @@ class PurgeWorker
         # HTTP 4xx means a purge is either running or not able to run,
         # so skip the current room
         rescue MatrixSdk::MatrixRequestError => e
-          visualizer.room_fail(room, e.message)
+          visualizer.room_fail(room, "#{e.class}: #{e.message}")
           visualizer.room_end(room)
           next
 
         # Don't skip the purge on HTTP 5XX or connection errors
         rescue MatrixSdk::MatrixConnectionError => e
-          visualizer.room_fail(room, e.message)
+          visualizer.room_fail(room, "#{e.class}: #{e.message}")
           to_purge.push(room)
           next
         rescue EOFError => e


### PR DESCRIPTION
This brings it more in line with how the compression code is built, as that code results in a smoother output for the user

It will also lower the frequency of the purge checks so that they only run every five seconds, which lowers the amount of log output slightly in Synapse.