### PR TITLE
Support modern Synapse

### DIFF
--- a/purge_worker.rb
+++ b/purge_worker.rb
@@ -10,7 +10,7 @@ class PurgeWorker
                  max_active: 5,
                  since: 24 * 60 * 60)
     if ignore_local
-      local_domain = MatrixSdk::MXID.new(client.client.mxid).domain
+      local_domain = MatrixSdk::MXID.new(client.client.mxid.to_s).domain
       rooms = rooms.reject do |r|
         r = MatrixSdk::MXID.new r.to_s
         r.domain == local_domain

--- a/synapse_client.rb
+++ b/synapse_client.rb
@@ -24,7 +24,7 @@ class SynapseClient
   def enqueue_room_purge(room_id, since)
     result = @client.api.request(
       :post,
-      :client_r0, "/admin/purge_history/#{ERB::Util.url_encode room_id}",
+      :admin_v1, "/purge_history/#{ERB::Util.url_encode room_id}",
       body: { purge_up_to_ts: since.to_i * 1000 }
     )
     result[:purge_id]
@@ -42,16 +42,20 @@ class SynapseClient
 
   def purge_running?(purge_id)
     get_purge_status(purge_id) == :active
+  rescue MatrixSdk::MatrixNotFoundError
+    false
   end
 
   def purge_finished?(purge_id)
     get_purge_status(purge_id) != :active
+  rescue MatrixSdk::MatrixNotFoundError
+    true
   end
 
   def get_purge_status(purge_id)
     result = @client.api.request(
       :get,
-      :client_r0, "/admin/purge_history_status/#{purge_id}"
+      :admin_v1, "/purge_history_status/#{ERB::Util.url_encode purge_id}"
     )
     result[:status].to_sym
   end


### PR DESCRIPTION
The old style `/_matrix/client/r0/admin` endpoints are no more, now they require the use of `/_synapse/admin/v1` instead.  
This fix requires the latest git version of the Ruby SDK to function

Also slipped in a fix for using `ADMIN_TOKEN` as well as a fix for a possible deadlock if Synapse were to restart during the purge.